### PR TITLE
Tighten up spec for tile.content

### DIFF
--- a/schema/tile.schema.json
+++ b/schema/tile.schema.json
@@ -22,7 +22,7 @@
         },
         "content" : {
             "extends" : { "$ref" : "tile.content.schema.json" },
-            "description" : "Metadata about the tile's content and a link to the content. When this is omitted the tile is just used for culling."
+            "description" : "Metadata about the tile's content and a link to the content. When this is omitted the tile is just used for culling. This is required for leaf tiles."
         },
         "children" : {
             "type" : "array",


### PR DESCRIPTION
Made `tile.content` required for leaf nodes to support this:
```
// When a tile with content is loaded, its parent can safely refine to it without any gaps in rendering
// Since an empty tile doesn't have content of its own, its descendants with content need to be loaded
// before the parent is able to refine to it.
```