### PR TITLE
Color Comments

### DIFF
--- a/Styling/README.md
+++ b/Styling/README.md
@@ -43,29 +43,40 @@ All of the types except `Color` are derived from JavaScript.  `Color` is derived
 * `undefined`
 * `1.0`
 * `'Cesium'`
-* `Color('#00FFFF')`
+* `color('#00FFFF')`
 
 ### Color
 
 Colors are created with the following constructor functions:
-* `Color(keyword : String)`
-* `Color(6-digit-hex : String)`
-* `Color(3-digit-hex : String)`
+* `color(keyword : String)`
+* `color(6-digit-hex : String)`
+* `color(3-digit-hex : String)`
 * `rgb(red : Number, green : Number, blue : number)`
 * `rgba(red : Number, green : Number, blue : number, alpha : Number)`
 * `hsl(hue : Number, saturation : Number/Percentage, lightness : Number/Percentage)`
 * `hsla(hue : Number, saturation : Number/Percentage, lightness : Number/Percentage, alpha : Number)`
 
 Colors defined by keyword (e.g. `cyan`) or hex rgb (e.g., `#00FFFF`) are passed as strings to the `Color` constructor (so that they can be differentiated from string types).  For example:
-* `Color('cyan')`
-* `Color('#00FFFF')`
-* `Color('#0FF')`
+* `color('cyan')`
+* `color('#00FFFF')`
+* `color('#0FF')`
 
-**TODO: What does `Color()` produce?  What should it?  WHITE or DeveloperError?**
+**TODO: What does `color()` produce?  What should it?  WHITE or DeveloperError?**
+```
+// If we want to go with Cesium behavior, an empty color() produces white. 
+```
 
 Colors defined with decimal rgb or hsl are defined with `rgb` and `hsl` functions, respectively, just like in CSS.  For example:
 * `rgb(100, 255, 190)`
 * `hsl(250, 60%, 70%)`
+
+```
+// I implemented hsl similarly to cesium behavior, ie all values being number from 0.0-1.0. I think if people want to set the color programatically like:
+
+"color" : "rgb(255, 0, 0, (${Visible} ? 255 : 0))"
+
+we should not have the %. Also % do not parse wil jsep, which would make the % difficult to implement.
+```
 
 The range for rgb components is `0` to `255`, inclusive.  For `hsl`, the range for hue is `0` to `255`, and the range for saturation and lightness is `0%` to `100%`, inclusive.
 
@@ -74,10 +85,19 @@ Colors defined with `rgba` or `hsla` have a fourth argument that is an alpha com
 * `hsla(250, 60%, 70%, 0.75)`
 
 **TODO: is keyword case sensitive?**
+```
+// According to W3, they are not case sensative
+```
 
-**TODO: should `Color` have an optional second argument for alpha, e.g., `Color('red', 0.5)`?  I think so.**
+**TODO: should `color` have an optional second argument for alpha, e.g., `Color('red', 0.5)`?  I think so.**
+```
+// while that is not normal css bevhavior, I would say that is easy to implement and useful, so yes. 
+```
 
 **TODO: `rgb`, `hsl`, `rgba`, and `hsla` should require all their arguments (assuming that is true in CSS).**
+```
+// Yes, currently I have a todo in the code to check for this.
+```
 
 ## File Extension
 

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -43,61 +43,40 @@ All of the types except `Color` are derived from JavaScript.  `Color` is derived
 * `undefined`
 * `1.0`
 * `'Cesium'`
-* `color('#00FFFF')`
+* `Color('#00FFFF')`
 
 ### Color
 
 Colors are created with the following constructor functions:
-* `color(keyword : String)`
-* `color(6-digit-hex : String)`
-* `color(3-digit-hex : String)`
+* `Color(keyword : String)`
+* `Color(6-digit-hex : String)`
+* `Color(3-digit-hex : String)`
 * `rgb(red : Number, green : Number, blue : number)`
 * `rgba(red : Number, green : Number, blue : number, alpha : Number)`
-* `hsl(hue : Number, saturation : Number/Percentage, lightness : Number/Percentage)`
-* `hsla(hue : Number, saturation : Number/Percentage, lightness : Number/Percentage, alpha : Number)`
+* `hsl(hue : Number, saturation : Number, lightness : Number)`
+* `hsla(hue : Number, saturation : Number, lightness : Number, alpha : Number)`
 
-Colors defined by keyword (e.g. `cyan`) or hex rgb (e.g., `#00FFFF`) are passed as strings to the `Color` constructor (so that they can be differentiated from string types).  For example:
-* `color('cyan')`
-* `color('#00FFFF')`
-* `color('#0FF')`
+Colors defined by a case-insensitive keyword (e.g. `cyan`) or hex rgb (e.g., `#00FFFF`) are passed as strings to the `Color` constructor (so that they can be differentiated from string types).  For example:
+* `Color('cyan')`
+* `Color('#00FFFF')`
+* `Color('#0FF')`
 
-**TODO: What does `color()` produce?  What should it?  WHITE or DeveloperError?**
-```
-// If we want to go with Cesium behavior, an empty color() produces white. 
-```
+The `Color` constructor has an optional second argument that is an alpha component to define opacity, where `0.0` is fully transparent and `1.0` is fully opaque.  For example:
+* `Color('cyan', 0.5)`
+
+An empty `Color` constructor `Color()` produces white.
 
 Colors defined with decimal rgb or hsl are defined with `rgb` and `hsl` functions, respectively, just like in CSS.  For example:
 * `rgb(100, 255, 190)`
-* `hsl(250, 60%, 70%)`
+* `hsl(1.0, 0.6, 0.7)`
 
-```
-// I implemented hsl similarly to cesium behavior, ie all values being number from 0.0-1.0. I think if people want to set the color programatically like:
-
-"color" : "rgb(255, 0, 0, (${Visible} ? 255 : 0))"
-
-we should not have the %. Also % do not parse wil jsep, which would make the % difficult to implement.
-```
-
-The range for rgb components is `0` to `255`, inclusive.  For `hsl`, the range for hue is `0` to `255`, and the range for saturation and lightness is `0%` to `100%`, inclusive.
+The range for rgb components is `0` to `255`, inclusive.  For `hsl`, the range for hue, saturation, and lightness is `0.0` to `1.0`, inclusive.
 
 Colors defined with `rgba` or `hsla` have a fourth argument that is an alpha component to define opacity, where `0.0` is fully transparent and `1.0` is fully opaque.  For example:
 * `rgba(100, 255, 190, 0.25)`
-* `hsla(250, 60%, 70%, 0.75)`
+* `hsla(1.0, 0.6, 0.7, 0.75)`
 
-**TODO: is keyword case sensitive?**
-```
-// According to W3, they are not case sensative
-```
-
-**TODO: should `color` have an optional second argument for alpha, e.g., `Color('red', 0.5)`?  I think so.**
-```
-// while that is not normal css bevhavior, I would say that is easy to implement and useful, so yes. 
-```
-
-**TODO: `rgb`, `hsl`, `rgba`, and `hsla` should require all their arguments (assuming that is true in CSS).**
-```
-// Yes, currently I have a todo in the code to check for this.
-```
+The functions `rgb`, `hsl`, `rgba`, and `hsla` require all their arguments.
 
 ## File Extension
 


### PR DESCRIPTION
I added my comments below the TODO's.

The `color('white')` constructor I implemented is lowercase, similar to `rgb()`, `hsl()`, etc. but I can see why it could be argued to be uppercase. I changed all occurrences here to lowercase, but if I should change to implementation to uppercase, let me know.