### PR TITLE
RGB565 color format for PointCloud

### DIFF
--- a/TileFormats/PointCloud/README.md
+++ b/TileFormats/PointCloud/README.md
@@ -65,6 +65,7 @@ If both `NORMAL` and `NORMAL_OCT16P` are defined for a point, the higher precisi
 | `POSITION_QUANTIZED` | `uint16[3]` | A 3-component array of numbers containing `x`, `y`, and `z` in quantized Cartesian coordinates for the position of the point. | :white_check_mark: Yes, unless `POSITION` is defined. |
 | `RGBA` | `uint8[4]` | A 4-component array of values containing the `RGBA` color of the point. | :red_circle: No. |
 | `RGB` | `uint8[3]` | A 3-component array of values containing the `RGB` color of the point. | :red_circle: No. |
+| `RGB565` | `uint16` | A lossy compressed color format that packs the `RGB` color into 16 bits, providing 5 bits for red, 6 bits for green, and 5 bits for blue. | :red_circle: No. |
 | `NORMAL` | `float32[3]`| A unit vector defining the normal of the point. | :red_circle: No. |
 | `NORMAL_OCT16P` | `uint8[2]` | An oct-encoded unit vector with 16-bits of precision defining the normal of the point. | :red_circle: No. |
 | `BATCH_ID` | `uint8`, `unit16` (default), or `uint32` | The `batchId` of the point that can be used to retrieve metadata from the `Batch Table`. | :red_circle: No. |
@@ -108,7 +109,7 @@ Quantized positions can be mapped to model space using the formula:
 
 ### Point Colors
 
-If more than one color semantic is defined, the precedence order is `RGBA`, `RGB`, then `CONSTANT_RGBA`. For example, if a tile's feature table contains both `RGBA` and `CONSTANT_RGBA` properties, the runtime would render with per-point colors using `RGBA`.
+If more than one color semantic is defined, the precedence order is `RGBA`, `RGB`, `RGB565`, then `CONSTANT_RGBA`. For example, if a tile's feature table contains both `RGBA` and `CONSTANT_RGBA` properties, the runtime would render with per-point colors using `RGBA`.
 
 If no color semantics are defined, the runtime is free to color points using an application-specific default color.
 

--- a/schema/pnts.featureTable.schema.json
+++ b/schema/pnts.featureTable.schema.json
@@ -20,6 +20,9 @@
             "RGB" : {
                 "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
             },
+            "RGB565" : {
+                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+            },
             "NORMAL" : {
                 "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
             },


### PR DESCRIPTION
For https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/22#issuecomment-231618325
Cesium implementation: https://github.com/AnalyticalGraphicsInc/cesium/pull/4315

I can also provide a code sample for generating RGB565 colors if that seems useful to have.