### PR TITLE
Add point cloud styling section

### DIFF
--- a/Styling/README.md
+++ b/Styling/README.md
@@ -23,9 +23,8 @@ Example: Creating a color ramp based on building height.
 * Gabby Getz, [@ggetz](https://github.com/ggetz)
 * Matt Amato, [@matt_amato](https://twitter.com/matt_amato)
 * Tom Fili, [@CesiumFili](https://twitter.com/CesiumFili)
-* Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi)
 * Sean Lilley, [@lilleyse](https://github.com/lilleyse)
-
+* Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi)
 
 Contents:
 

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -472,7 +472,7 @@ ${temperatures['values'][0]} === 70 // Same as (temperatures[values])[0] and tem
 
 ### Point Cloud
 
-In addition to evaluating a point's `color` and `show` properties, a point cloud style may evaluate `pointSize`, or the size of each point in pixels. The default `pointSize` is `1.0`.
+A [Point Cloud](../TileFormats/PointCloud/README.md) is a collection of points that may be styled like other features. In addition to evaluating a point's `color` and `show` properties, a point cloud style may evaluate `pointSize`, or the size of each point in pixels. The default `pointSize` is `1.0`.
 ```json
 {
     "color" : "color('red')",
@@ -480,20 +480,20 @@ In addition to evaluating a point's `color` and `show` properties, a point cloud
 }
 ```
 
-Implementations may clamp the evaluated `pointSize` to the system's supported point size range. For example, WebGL renderers may query `ALIASED_POINT_SIZE_RANGE` to get the system limits when rendering with `POINTS`.
+Implementations may clamp the evaluated `pointSize` to the system's supported point size range. For example, WebGL renderers may query `ALIASED_POINT_SIZE_RANGE` to get the system limits when rendering with `POINTS`. A `pointSize` of `1.0` must be supported.
 
-Point cloud styles may also reference per-point semantics including position, color, and normal to allow for more flexible styling of the source data.
-* `${POSITION}` is an array of three values representing the xyz coordinates of the point before the `RTC_CENTER` and tile transform are applied. When the positions are quantized, `${POSITION}` refers to the position after the `QUANTIZED_VOLUME_SCALE` is applied, but before `QUANTIZED_VOLUME_OFFSET` is applied.
-* `${COLOR}` evaluates to a Color type, where each of the rgba color components are in the range `0.0` to `1.0`.
-* `${NORMAL}` is an array of three values representing the normal of the point before the tile transform is applied. When normals are oct-encoded `${NORMAL}` refers to the decoded normal.
+Point cloud styles may also reference semantics from the [Feature Table](../TileFormats/PointCloud/README.md#feature-table) including position, color, and normal to allow for more flexible styling of the source data.
+* `${POSITION}` is a `vec3` storing the xyz Cartesian coordinates of the point before the `RTC_CENTER` and tile transform are applied. When the positions are quantized, `${POSITION}` refers to the position after the `QUANTIZED_VOLUME_SCALE` is applied, but before `QUANTIZED_VOLUME_OFFSET` is applied.
+* `${COLOR}` evaluates to a `Color` storing the rgba color of the point. When the feature table's color semantic is `RGB` or `RGB565`, `${COLOR}.alpha` is `1.0`. If no color semantic is defined, `${COLOR}` evaluates to the application-specific default color.
+* `${NORMAL}` is a `vec3` storing the normal, in Cartesian coordinates, of the point before the tile transform is applied. When normals are oct-encoded `${NORMAL}` refers to the decoded normal. If no normal semantic is defined in the feature table, `${NORMAL}` evaluates to `undefined`.
 
 For example:
 
 ```json
 {
     "color" : "${COLOR} * color('red')'",
-    "show" : "${POSITION}[0] > 0.5",
-    "pointSize" : "${NORMAL}[0] > 0 ? 2 : 1"
+    "show" : "${POSITION}.x > 0.5",
+    "pointSize" : "${NORMAL}.x > 0 ? 2 : 1"
 }
 ```
 

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -24,6 +24,7 @@ Example: Creating a color ramp based on building height.
 * Matt Amato, [@matt_amato](https://twitter.com/matt_amato)
 * Tom Fili, [@CesiumFili](https://twitter.com/CesiumFili)
 * Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi)
+* Sean Lilley, [@lilleyse](https://github.com/lilleyse)
 
 
 Contents:
@@ -40,6 +41,7 @@ Contents:
       * [RegExp](#regexp)
    * [Conversions](#conversions)
    * [Variables](#variables)
+   * [Point Cloud](#point-cloud)
    * [Notes](#notes)
 * [File Extension](#file-extension)
 * [MIME Type](#mime-type)
@@ -468,6 +470,37 @@ ${temperatures['scale']} === 'fahrenheit'
 ${temperatures.values[0]} === 70
 ${temperatures['values'][0]} === 70 // Same as (temperatures[values])[0] and temperatures.values[0]
 ```
+
+### Point Cloud
+
+In addition to evaluating a point's `color` and `show` properties, a point cloud style may evaluate `pointSize`, or the size of each point in pixels. The default `pointSize` is `1.0`.
+```json
+{
+    "color" : "color('red')",
+    "pointSize" : "${Temperature} * 0.5"
+}
+```
+
+Implementations may clamp the evaluated `pointSize` to the system's supported point size range. For example, WebGL renderers may query `ALIASED_POINT_SIZE_RANGE` to get the system limits when rendering with `POINTS`.
+
+Point cloud styles may also reference per-point semantics including position, color, and normal to allow for more flexible styling of the source data.
+* `${POSITION}` is an array of three values representing the xyz coordinates of the point before the `RTC_CENTER` and tile transform are applied. When the positions are quantized, `${POSITION}` refers to the position after the `QUANTIZED_VOLUME_SCALE` is applied, but before `QUANTIZED_VOLUME_OFFSET` is applied.
+* `${COLOR}` evaluates to a Color type, where each of the rgba color components are in the range `0.0` to `1.0`.
+* `${NORMAL}` is an array of three values representing the normal of the point before the tile transform is applied. When normals are oct-encoded `${NORMAL}` refers to the decoded normal.
+
+For example:
+
+```json
+{
+    "color" : "${COLOR} * color('red')'",
+    "show" : "${POSITION}[0] > 0.5",
+    "pointSize" : "${NORMAL}[0] > 0 ? 2 : 1"
+}
+```
+
+#### Point Cloud Shader Styling
+
+**TODO : add note about GLSL implementations requires strict type comparisons among other things: https://github.com/AnalyticalGraphicsInc/cesium/issues/3241**
 
 ### Notes
 

--- a/Styling/schema/pnts.style.schema.json
+++ b/Styling/schema/pnts.style.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "id" : "pnts.style.schema.json",
+    "title" : "Point Cloud Style",
+    "type" : "object",
+    "description" : "A 3D Tiles style with additional properties for Point Clouds.",
+    "allOf" : [{
+        "$ref" : "style.schema.json"
+    }, {
+        "properties" : {
+            "pointSize": {
+                "oneOf": [{
+                    "$ref": "style.numberExpression.schema.json"
+                }, {
+                    "$ref": "style.condition.schema.json"
+                }],
+                "description": "Determines the size of the points in pixels.",
+                "default": 1.0
+            }
+        }
+    }],
+    "additionalProperties" : false
+}

--- a/Styling/schema/style.numberExpression.schema.json
+++ b/Styling/schema/style.numberExpression.schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "id" : "style.numberExpression.schema.json",
+    "title" : "number expression",
+    "type" : ["number", "string"],
+    "description" : "3D Tiles style expression that evaluates to a number."
+}

--- a/Styling/schema/style.schema.json
+++ b/Styling/schema/style.schema.json
@@ -20,7 +20,7 @@
             }, {
                 "$ref" : "style.condition.schema.json"
             }],
-            "description" : "Determines the 'highlight color' multiplied with the feature's intrinsic color.",
+            "description" : "Determines the color blended with the feature's intrinsic color.",
             "default" : "Color('#FFFFFF')"
         },
         "meta" : {


### PR DESCRIPTION
Added `pointSize`, `${POSITION}`, `${COLOR}`, `${NORMAL}`

@pjcozzi I'm in the process of writing a section for shader styling. Did we decide on a final solution for the current GLSL styling limitations? I have the current issues in https://github.com/AnalyticalGraphicsInc/cesium/issues/3241 under the `Point Cloud Shader Styling` section:

> - [ ] **Point Cloud Shader Styling**
>   - [ ] Unsupported:
>     - [ ] `isNan`, `isFinite`(supported in later versions of GLSL with `isnan` and `isinf`)
>     - [ ] Strings, not supported in the GLSL styling engine or the batch table binary
>     - [ ] Regular expressions
>     - [ ] Arrays that aren't length 2, 3, or 4.
>     - [ ] null and undefined - use a default value like 0?
>     - [ ] type mismatching - comparing floats to bools to vecn will result in shader compilation errors

and some notes here: https://github.com/AnalyticalGraphicsInc/cesium/pull/4336#issuecomment-250238675

I am also going to write a section for the new `ColorBlendMode` types in https://github.com/AnalyticalGraphicsInc/cesium/pull/4451. Technically this is not part of the declarative styling language though, so should it go in the `Styling` section or the main README ?
