### PR TITLE
batchId type update

### DIFF
--- a/TileFormats/Batched3DModel/README.md
+++ b/TileFormats/Batched3DModel/README.md
@@ -42,7 +42,7 @@ in the Cesium implementation of 3D Tiles.
 
 ## Batch Table
 
-The _Batch Table_ contains per-model application-specific metadata, indexable by `batchId`, that can be used for declarative styling and application-specific use cases such as populating a UI or issuing a REST API request.  In the Binary glTF section, each vertex has an unsigned short `batchId` attribute in the range `[0, number of models in the batch - 1]`.  The `batchId` indicates the model to which the vertex belongs.  This allows models to be batched together and still be identifiable.
+The _Batch Table_ contains per-model application-specific metadata, indexable by `batchId`, that can be used for declarative styling and application-specific use cases such as populating a UI or issuing a REST API request.  In the Binary glTF section, each vertex has an numeric `batchId` attribute in the integer range `[0, number of models in the batch - 1]`.  The `batchId` indicates the model to which the vertex belongs.  This allows models to be batched together and still be identifiable.
 
 See the [Batch Table](../BatchTable/README.md) reference for more information.
 

--- a/TileFormats/Instanced3DModel/README.md
+++ b/TileFormats/Instanced3DModel/README.md
@@ -76,7 +76,7 @@ If `NORMAL_UP`, `NORMAL_RIGHT`, `NORMAL_UP_OCT32P`, and `NORMAL_RIGHT_OCT32P` ar
 | `NORMAL_RIGHT_OCT32P` | `uint16[2]` | An oct-encoded unit vector with 32-bits of precision defining the `right` direction for the orientation of the instance. Must be orthogonal to `up`. | :red_circle: No, unless `NORMAL_UP_OCT32P` is defined. |
 | `SCALE` | `float32` | A number defining a scale to apply to all axes of the instance. | :red_circle: No. |
 | `SCALE_NON_UNIFORM` | `float32[3]` | A 3-component array of numbers defining the scale to apply to the `x`, `y`, and `z` axes of the instance. | :red_circle: No. |
-| `BATCH_ID` | `unit16` | The `batchId` of the instance that can be used to retrieve metadata from the `Batch Table`. | :red_circle: No. |
+| `BATCH_ID` | `uint8`, `unit16` (default), or `uint32` | The `batchId` of the instance that can be used to retrieve metadata from the `Batch Table`. | :red_circle: No. |
 
 #### Global Semantics
 


### PR DESCRIPTION
As discussed in https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/141#issuecomment-257335562.

@lilleyse does this require any Cesium implementation updates?

Note that `pnts`/`i3dm` are slightly different than `b3dm` since `b3dm` would allow float batchids.  I do not think that is appropriate in the context of `pnts`/`i3dm`.