### PR TITLE
Added examples for the functions clamp, mix

### DIFF
--- a/Styling/README.md
+++ b/Styling/README.md
@@ -702,7 +702,7 @@ Constrains a value to lie between two values.
 
 ```json
 {
-    "show" : "(clamp(${Angle}, 0.0, 90.0) / 90.0) > 0.5"
+    "color" : "color() * clamp(${temperature}, 0.1, 0.2)"
 }
 ```
 
@@ -714,7 +714,7 @@ Computes the linear interpolation of x and y.
 
 ```json
 {
-    "color" : "color() * clamp(${temperature}, 0.1, 0.2)"
+    "show" : "mix(20.0, ${Angle}, 0.5) > 25.0"
 }
 ```
 

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -714,7 +714,7 @@ Computes the linear interpolation of x and y.
 
 ```json
 {
-    "show" : "mix(20.0, ${Angle}, 0.5) > 25.0"
+    "color" : "color() * clamp(${temperature}, 0.1, 0.2)"
 }
 ```
 

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -628,23 +628,22 @@ Converts the number from radians to degrees.
 
 `clamp(value : Number,  min : Number, max : Number) : Number`
 
-Returns value if it is greater than min and less than max. Otherwise, if value is less than min, min is returned, and if value is greater than max, max is returned.
+Constrains a value to lie between two values.
 
 ```json
 {
-    "show" : "clamp(${Angle}, 0.0, 90.0) > 45.0"
+    "show" : "(clamp(${Angle}, 0.0, 90.0) / 90.0) > 0.5"
 }
 ```
 
 #### mix
 
-`clamp(p : Number,  q : Number, time : Number) : Number`
+`mix(x : Number,  y : Number, a: Number) : Number`
 
-Computes the linear interpolation of p and q.
+Computes the linear interpolation of x and y.
 
 ```json
 {
-
     "show" : "mix(20.0, ${Angle}, 0.5) > 25.0"
 }
 ```

--- a/Styling/README.md
+++ b/Styling/README.md
@@ -513,6 +513,8 @@ The following built-in functions are supported by the styling language:
 * [`atan`](#atan)
 * [`radians`](#radians)
 * [`degrees`](#degrees)
+* [`clamp`](#clamp)
+* [`mix`](#mix)
 
 #### abs
 
@@ -619,6 +621,31 @@ Converts the number from radians to degrees.
 ```json
 {
     "show" : "degrees(${Angle}) > 45.0"
+}
+```
+
+#### clamp
+
+`clamp(value : Number,  min : Number, max : Number) : Number`
+
+Returns value if it is greater than min and less than max. Otherwise, if value is less than min, min is returned, and if value is greater than max, max is returned.
+
+```json
+{
+    "show" : "clamp(${Angle}, 0.0, 90.0) > 45.0"
+}
+```
+
+#### mix
+
+`clamp(p : Number,  q : Number, time : Number) : Number`
+
+Computes the linear interpolation of p and q.
+
+```json
+{
+
+    "show" : "mix(20.0, ${Angle}, 0.5) > 25.0"
 }
 ```
 


### PR DESCRIPTION
Related to issue [#4694](https://github.com/AnalyticalGraphicsInc/cesium/issues/4694) in Cesium. @lilleyse  The updated README looks like this:


#### clamp

`clamp(value : Number,  min : Number, max : Number) : Number`

Constrains a value to lie between two values.

```json
{
    "show" :  "(clamp(${Angle}, 0.0, 90.0) / 90.0) > 0.5"
}
```

#### mix

`mix(x : Number,  y : Number, a: Number) : Number`

Computes the linear interpolation of x and y.

```json
{
    "show" : "mix(20.0, ${Angle}, 0.5) > 25.0"
}
```
