### PR TITLE
Prefix BATCHID semantic with an underscore

### DIFF
--- a/TileFormats/Batched3DModel/README.md
+++ b/TileFormats/Batched3DModel/README.md
@@ -68,7 +68,7 @@ normal:   [xyz, xyz, xyz, ..., xyz, xyz, xyz, ..., xyz, xyz, xyz, ...]
 ```
 Note that a vertex can't belong to more than one model; in that case, the vertex needs to be duplicated so the `batchId`s can be assigned.
 
-The `batchId` is identified by the glTF technique parameter semantic `BATCHID`.  For example:
+The `batchId` is identified by the glTF technique parameter semantic `_BATCHID`.  For example:
 
 ```JSON
 "technique": {
@@ -77,7 +77,7 @@ The `batchId` is identified by the glTF technique parameter semantic `BATCHID`. 
     },
     "parameters": {
         "batchId": {
-            "semantic": "BATCHID",
+            "semantic": "_BATCHID",
             "type": 5126
         }
     }
@@ -92,7 +92,7 @@ attribute float a_batchId;
 
 The vertex shader can be modified at runtime to use `a_batchId` to access individual models in the batch, e.g., to change their color.
 
-When a Batch Table is present, the `batchId` attribute (with the parameter semantic `BATCHID`) is required; otherwise, it is not.
+When a Batch Table is present, the `batchId` attribute (with the parameter semantic `_BATCHID`) is required; otherwise, it is not.
 
 Although not strictly required, clients may find the glTF [CESIUM_RTC](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_RTC/README.md) extension useful for high-precision rendering.
 


### PR DESCRIPTION
@pjcozzi, from https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/191.

[Link](https://github.com/lasalvavida/3d-tiles/tree/batchid-prefix-underscore/TileFormats/Batched3DModel)

Also do we want to change the semantic to the more correct `_BATCH_ID -> batchId` with an underscore between `BATCH` and `ID` since we're making this change anyway?