### PR TITLE
Length to half-length for box schema

### DIFF
--- a/schema/boundingVolume.schema.json
+++ b/schema/boundingVolume.schema.json
@@ -7,7 +7,7 @@
     "properties" : {
         "box" : {
             "type" : "array",
-            "description" : "An array of 12 numbers that define an oriented bounding box.  The first three elements define the x, y, and z values for the center of the box.  The next three elements (with indices 3, 4, and 5) define the x axis direction and length.  The next three elements (indices 6, 7, and 8) define the y axis direction and length.  The last three elements (indices 9, 10, and 11) define the z axis direction and length.",
+            "description" : "An array of 12 numbers that define an oriented bounding box.  The first three elements define the x, y, and z values for the center of the box.  The next three elements (with indices 3, 4, and 5) define the x axis direction and half-length.  The next three elements (indices 6, 7, and 8) define the y axis direction and half-length.  The last three elements (indices 9, 10, and 11) define the z axis direction and half-length.",
             "items" : {
                 "type" : "number"
             },


### PR DESCRIPTION
The values in the box should be half lengths, not full lengths of the axis directions.