### PR TITLE
Fixed broken links in README

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -481,7 +481,7 @@ See [Property reference](#property-reference) for the tile JSON schema reference
 
 3D Tiles uses one main tileset JSON file as the entry point to define a tileset. Both entry and external tileset JSON files are not required to follow a specific naming convention.
 
-Here is a subset of the tileset JSON used for [Canary Wharf](http://cesiumjs.org/CanaryWharf/) (also see the complete file, [`tileset.json`](examples/tileset.json)):
+Here is a subset of the tileset JSON used for [Canary Wharf](http://cesiumjs.org/CanaryWharf/) (also see the complete file, [`tileset.json`](../examples/tileset.json)):
 ```json
 {
   "asset" : {
@@ -973,7 +973,7 @@ Additional properties are allowed.
 
 Application-specific data.
 
-* **JSON schema**: [`extras.schema.json`](../../schema/extras.schema.json)
+* **JSON schema**: [`extras.schema.json`](schema/extras.schema.json)
 
 
 


### PR DESCRIPTION
These two links are broken in `specification/README.md`: 

* The tileset.json link under https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#tileset-json
* The extras.schema.json link under https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#extras-1

This PR fixes them. 