### PR TITLE
Feature table schema fix

### DIFF
--- a/specification/schema/featureTable.schema.json
+++ b/specification/schema/featureTable.schema.json
@@ -14,6 +14,11 @@
                     "type" : "number",
                     "description": "The offset into the buffer in bytes.",
                     "minimum" : 0
+                },
+                "componentType" : {
+                    "type" : "number",
+                    "description": "The datatype of components in the property. This is defined only if the semantic allows for overriding the implicit component type. These cases are specified in each tile format.",
+                    "enum" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "DOUBLE"]
                 }
             },
             "required" : ["byteOffset"]
@@ -28,13 +33,13 @@
             "title" : "Property",
             "description" : "A user-defined property which specifies per-feature application-specific metadata in a tile. Values either can be defined directly in the JSON as an array, or can refer to sections in the binary body with a `BinaryBodyReference` object.",
             "oneOf" : [
-                { 
-                    "$ref" : "#/definitions/binaryBodyReference" 
-                }, { 
+                {
+                    "$ref" : "#/definitions/binaryBodyReference"
+                }, {
                     "type" : "array",
                     "items" : {
                         "type" : "number"
-                    } 
+                    }
                 }, {
                     "type" : "number"
                 }


### PR DESCRIPTION
Fixes #346 

From https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification/TileFormats/FeatureTable#json-header

> Some semantics allow for overriding the implicit component type. These cases are specified in each tile format, e.g., "BATCH_ID" : { "byteOffset" : 24, "componentType" : "UNSIGNED_BYTE"}.

This was not included in the schema.

@ggetz can you review?
