### PR TITLE
fix example for Batched3DModel _BATCHID attribute

### DIFF
--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -120,7 +120,7 @@ The `batchId` parameter is specified in a glTF mesh [primitive](https://github.c
         {
             "bufferView": 1,
             "byteOffset": 0,
-            "componentType": 5125,
+            "componentType": 5126,
             "count": 4860,
             "max": [2],
             "min": [0],


### PR DESCRIPTION
The gltf 2.0 specification doesn't allow `UNSIGNED_INT` accessors for general vertex attributes: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessorcomponenttype-white_check_mark

This PR updates the example to use `FLOAT` for the batch IDs accessor example instead.